### PR TITLE
Update README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Features related to authentication, production hardening, deployment, and multi-
 
 ## Stack
 - Node.js 20
-- Express 4
+- Express 5
 - irc‑framework
 - ws
 - jsonwebtoken
@@ -20,9 +20,8 @@ Features related to authentication, production hardening, deployment, and multi-
 ### Local
 ```bash
 git clone <repo‑url>
-cd web-irc-backend
+cd pulse-irc-backend
 npm install
-cp .env.example .env
 npm run dev
 ```
 
@@ -37,8 +36,7 @@ docker compose up --build
 ## Environment
 ```
 PORT=3000
-IRC_SERVER=irc.libera.chat
-IRC_NICK=webbot
+# IRC connection details are supplied by the frontend at runtime.
 ```
 
 ## Scripts
@@ -70,4 +68,4 @@ Push the Docker image to any registry or deploy to Fly.io, Render, or a VPS.
 -->
 
 ## License
-MIT
+ISC


### PR DESCRIPTION
## Summary
- use correct repo folder name in quickstart instructions
- drop reference to nonexistent `.env.example`
- note Express 5 in the stack
- document that IRC connection settings come from the frontend
- update license section to ISC to match `package.json`

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` *(fails: eslintrc config error)*

------
https://chatgpt.com/codex/tasks/task_e_687a8628d3c0832b94fc0bc7c88f71f4