### PR TITLE
Fix duplicate WebSocket API header

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -97,14 +97,6 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
 - **Endpoint:** `ws://<backend-host>:<port>` (default port: 3000)
 - **Protocol:** JSON messages
 
-## WebSocket API
-
-- **Endpoint:** `ws://<backend-host>:<port>` (default port: 3000)
-- **Protocol:** JSON messages
-
-
-
-
 ### Message Types (Client → Server)
 
 - **Connect to IRC server**


### PR DESCRIPTION
## Summary
- remove second `## WebSocket API` section from DOCUMENTATION

## Testing
- `npm run lint` *(fails: Package subpath not exported)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a9594f7dc832bb13a59a1a3fd553e