### PR TITLE
Add contributing docs and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug Report
+about: Report a problem with the project
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps to reproduce**
+How to reproduce the behavior.
+
+**Expected behavior**
+What you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+---
+name: Feature Request
+about: Suggest an idea for the project
+labels: enhancement
+---
+
+**Describe the feature**
+A clear and concise description of the feature you're requesting.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Summary
+Explain the changes introduced in this PR.
+
+## Testing
+- [ ] `npm run lint`
+- [ ] `npm test`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+Thank you for wanting to contribute! This project is intended for personal use but contributions are welcome.
+
+## Setup
+
+1. Install [Node.js](https://nodejs.org/) 20 or later.
+2. Clone the repository and install dependencies:
+   ```bash
+   git clone <repo-url>
+   cd pulse-irc-backend
+   npm install
+   ```
+
+## Linting
+Run ESLint over the project:
+```bash
+npm run lint
+```
+Fix any reported issues before opening a pull request.
+
+## Formatting
+Format source files with Prettier:
+```bash
+npm run format
+```
+
+Please run the linter and formatter before submitting changes.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ PORT=3000
 - `npm run dev` – dev with nodemon
 - `npm start` – prod
 - `npm test` – tests
+- `npm run lint` – ESLint
+- `npm run format` – Prettier
 
 ## API
 
@@ -69,3 +71,6 @@ Push the Docker image to any registry or deploy to Fly.io, Render, or a VPS.
 
 ## License
 MIT
+
+## Contributing
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines including linting and formatting.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guidelines
- document lint/format scripts in README
- add issue and pull request templates

## Testing
- `npm run lint` *(fails: Package subpath './use-at-your-own-risk/recommended.js' is not defined)*
- `npm test` *(fails: Error: no test specified)*
- `npx prettier -c .` *(reports code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_687a9a14fdcc832b9342e0c1a2126f53