### PR TITLE
Add example env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+# Other variables can be added here as needed

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ yarn-error.log*
 # Environment variables
 .env
 .env.*
+!.env.example
 
 # OS files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ docker compose up --build
 -->
 
 ## Environment
+Copy `.env.example` to `.env` before running:
+
+```bash
+cp .env.example .env
+```
+
+Example contents:
+
 ```
 PORT=3000
 # IRC connection details are supplied by the frontend at runtime.


### PR DESCRIPTION
## Summary
- provide `.env.example` with default PORT
- allow `.env.example` in `.gitignore`
- document copying `.env.example` in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: package subpath './use-at-your-own-risk/recommended.js' not exported)*

------
https://chatgpt.com/codex/tasks/task_e_687aa8e2b4ec832b90ede0e9d416cbf7