### PR TITLE
Remove Docker section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,6 @@ npm install
 npm run dev
 ```
 
-
-<!--
-### Docker
-```bash
-docker compose up --build
-```
--->
-
 ## Environment
 ```
 PORT=3000
@@ -61,12 +53,6 @@ Example messages:
 <!--
 ### REST
 `POST /auth/login` → `{ "token": "..." }`
--->
-
-
-<!--
-## Deployment
-Push the Docker image to any registry or deploy to Fly.io, Render, or a VPS.
 -->
 
 ## License


### PR DESCRIPTION
## Summary
- delete Docker instructions from README since no Dockerfile exists

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687aac0e1748832b9dfab2167db6d936