### PR TITLE
Update docs on WebSocket paths

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,7 +7,7 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
 ## Protocol Overview and Connection Flow
 
 1. **Connect to WebSocket:**
-   - The frontend opens a WebSocket connection to the backend: `ws://<backend-host>:<port>` (default port: 3000).
+   - The frontend opens a WebSocket connection to the backend: `ws://<backend-host>:<port>` (default port: 3000). The server accepts connections on any path.
 2. **Send IRC Connect Message:**
    - The frontend must send a message of the form:
      ```json
@@ -98,7 +98,7 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
 
 ## WebSocket API
 
-- **Endpoint:** `ws://<backend-host>:<port>` (default port: 3000)
+ - **Endpoint:** `ws://<backend-host>:<port>` (default port: 3000). The server accepts connections on any path.
 - **Protocol:** JSON messages
 
 ### Message Types (Client → Server)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ PORT=3000
 ## API
 
 ### WebSocket
-Endpoint: `/ws`
+Endpoint: any path (example: `/ws`)
 
 Example messages:
 ```json


### PR DESCRIPTION
## Summary
- clarify that WebSocket server accepts connections on any path in README
- document same note in API docs

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687aaeb2d1c0832b91843eb3e8ecab75