### PR TITLE
Add IRC session disconnect message

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -124,6 +124,12 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
   ```json
   { "type": "names", "id": "example", "channel": "#channel" }
   ```
+- **Disconnect an IRC session**
+  ```json
+  { "type": "disconnect", "id": "example" }
+  ```
+  Gracefully closes the IRC connection for the specified session. The server
+  will reply with a `disconnected` message once the connection is closed.
 
 
 


### PR DESCRIPTION
## Summary
- add `disconnect` message type so the frontend can close a single IRC session
- expose `disconnect` helper in `ircClientFactory`
- document the new client message

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687aaff4e768832bbfecc3ac11f5ad2d