### PR TITLE
Add explicit TLS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 PORT=3000
-# Other variables can be added here as needed
+# Set to "true" to default to TLS when connecting to IRC servers if the frontend does not specify
+IRC_TLS=false

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,8 +1,6 @@
-
 # Backend API Documentation
 
 This document describes how to interact with the backend WebSocket IRC bridge for frontend integration. The backend now supports multiple independent IRC sessions over a single WebSocket connection. Each session is identified by a unique `id` supplied by the frontend.
-
 
 ## Protocol Overview and Connection Flow
 
@@ -10,13 +8,18 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
    - The frontend opens a WebSocket connection to the backend: `ws://<backend-host>:<port>` (default port: 3000). The server accepts connections on any path.
 2. **Send IRC Connect Message:**
    - The frontend must send a message of the form:
+
      ```json
-     { "type": "connect", "id": "server1", "server": "irc.example.net", "nick": "myNick" }
+     { "type": "connect", "id": "server1", "server": "irc.example.net", "nick": "myNick", "tls": true }
      ```
+
      - `server`: IRC server hostname (required)
      - `nick`: IRC nickname (required)
      - `password`: (optional) Password for servers that require authentication
+     - `tls`: (optional) `true` to use TLS, `false` to disable; if omitted the backend uses the `IRC_TLS` environment variable
+
    - No other IRC actions are allowed until the backend responds with `{"type": "irc-ready", "id": "<same id>"}`.
+
 3. **Wait for IRC Ready:**
    - The backend connects to the IRC server and performs the handshake.
    - If the requested nickname is already in use, the backend will automatically try a new nickname by appending random digits, and will notify the frontend of the new nickname with a message:
@@ -30,22 +33,28 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
    - The frontend must wait for this message before sending any channel join or IRC actions.
 4. **IRC Actions:**
    - After receiving `irc-ready`, the frontend can send:
-    - Join a channel:
-      ```json
-      { "type": "join", "id": "<id>", "channel": "#channel" }
-      ```
-     - Send a message:
-      ```json
-      { "type": "message", "id": "<id>", "channel": "#channel", "text": "Hello world" }
-      ```
-     - Part (leave) a channel:
-      ```json
-      { "type": "part", "id": "<id>", "channel": "#channel" }
-      ```
-     - Request nick list:
-      ```json
-      { "type": "names", "id": "<id>", "channel": "#channel" }
-      ```
+   - Join a channel:
+     ```json
+     { "type": "join", "id": "<id>", "channel": "#channel" }
+     ```
+   - Send a message:
+
+   ```json
+   { "type": "message", "id": "<id>", "channel": "#channel", "text": "Hello world" }
+   ```
+
+   - Part (leave) a channel:
+
+   ```json
+   { "type": "part", "id": "<id>", "channel": "#channel" }
+   ```
+
+   - Request nick list:
+
+   ```json
+   { "type": "names", "id": "<id>", "channel": "#channel" }
+   ```
+
    - The backend will relay IRC events and responses as described below.
 
 ## Example Session
@@ -53,12 +62,15 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
 1. **Frontend connects to backend WebSocket**
 2. **Frontend sends:**
    ```json
-   { "type": "connect", "id": "libera", "server": "irc.libera.chat", "nick": "alice" }
+   { "type": "connect", "id": "libera", "server": "irc.libera.chat", "nick": "alice", "tls": true }
    ```
+
+````
 3. **Backend responds (after IRC handshake):**
-   ```json
-   { "type": "irc-ready", "id": "libera" }
-   ```
+ ```json
+ { "type": "irc-ready", "id": "libera" }
+````
+
 4. **Frontend sends:**
    ```json
    { "type": "join", "id": "libera", "channel": "#test" }
@@ -98,14 +110,14 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
 
 ## WebSocket API
 
- - **Endpoint:** `ws://<backend-host>:<port>` (default port: 3000). The server accepts connections on any path.
+- **Endpoint:** `ws://<backend-host>:<port>` (default port: 3000). The server accepts connections on any path.
 - **Protocol:** JSON messages
 
 ### Message Types (Client → Server)
 
 - **Connect to IRC server**
   ```json
-  { "type": "connect", "id": "example", "server": "irc.example.net", "nick": "myNick" }
+  { "type": "connect", "id": "example", "server": "irc.example.net", "nick": "myNick", "tls": false }
   ```
   (Optionally, add `"password": "..."` for servers that require authentication.)
 - **Join a channel**
@@ -131,11 +143,6 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
   Gracefully closes the IRC connection for the specified session. The server
   will reply with a `disconnected` message once the connection is closed.
 
-
-
-
-
-
 ### Message Types (Server → Client)
 
 - **IRC connection ready**
@@ -149,47 +156,60 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
   ```
   Sent if the backend changes the IRC nickname due to a collision (e.g., the requested nick is already in use). The frontend should update its state to reflect the new nickname.
 
-
 **IRC message received**
-  ```json
-  { "type": "message", "id": "<id>", "from": "nick", "channel": "#channel", "text": "Hello" }
-  ```
+
+```json
+{ "type": "message", "id": "<id>", "from": "nick", "channel": "#channel", "text": "Hello" }
+```
 
 **Channel topic received**
-  ```json
-  { "type": "topic", "id": "<id>", "channel": "#channel", "topic": "...", "nick": "nick" }
-  ```
-  - `channel`: The channel name for which the topic applies.
-  - `topic`: The topic string as sent by the IRC server.
-  - `nick`: The nick of the user who set the topic (if available).
+
+```json
+{ "type": "topic", "id": "<id>", "channel": "#channel", "topic": "...", "nick": "nick" }
+```
+
+- `channel`: The channel name for which the topic applies.
+- `topic`: The topic string as sent by the IRC server.
+- `nick`: The nick of the user who set the topic (if available).
 
 **Server-level message (MOTD, notices, numerics, etc.)**
-  ```json
-  { "type": "server-message", "id": "<id>", "subtype": "motd|notice|001|002|...", "text": "..." }
-  ```
-  - `subtype`: Indicates the kind of server message (e.g., `motd` for Message of the Day, `notice` for server notices, or IRC numeric codes like `001`, `372`, etc.)
-  - `text`: The message content as sent by the IRC server.
+
+```json
+{ "type": "server-message", "id": "<id>", "subtype": "motd|notice|001|002|...", "text": "..." }
+```
+
+- `subtype`: Indicates the kind of server message (e.g., `motd` for Message of the Day, `notice` for server notices, or IRC numeric codes like `001`, `372`, etc.)
+- `text`: The message content as sent by the IRC server.
 
 **User joined a channel**
-  ```json
-  { "type": "join", "id": "<id>", "nick": "nick", "channel": "#channel" }
-  ```
+
+```json
+{ "type": "join", "id": "<id>", "nick": "nick", "channel": "#channel" }
+```
+
 **User parted a channel**
-  ```json
-  { "type": "part", "id": "<id>", "nick": "nick", "channel": "#channel" }
-  ```
+
+```json
+{ "type": "part", "id": "<id>", "nick": "nick", "channel": "#channel" }
+```
+
 **Nick list for a channel**
-  ```json
-  { "type": "names", "id": "<id>", "channel": "#channel", "nicks": ["nick1", "nick2", "nick3"] }
-  ```
+
+```json
+{ "type": "names", "id": "<id>", "channel": "#channel", "nicks": ["nick1", "nick2", "nick3"] }
+```
+
 **IRC connection closed**
-  ```json
-  { "type": "disconnected", "id": "<id>" }
-  ```
+
+```json
+{ "type": "disconnected", "id": "<id>" }
+```
+
 **Error**
-  ```json
-  { "type": "error", "id": "<id>", "error": "Error message" }
-  ```
+
+```json
+{ "type": "error", "id": "<id>", "error": "Error message" }
+```
 
 ## Health Check
 
@@ -199,11 +219,10 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
   { "status": "ok" }
   ```
 
-
-
 ## Environment Variables (Backend)
 
 - `PORT` - Port to run the backend server (default: 3000)
+- `IRC_TLS` - Default TLS setting for IRC connections (`true` or `false`, default `false`). Used when the connect message omits the `tls` field.
 
 IRC connection details are now provided by the frontend per WebSocket connection. The backend no longer uses `IRC_SERVER`, `IRC_NICK`, or `IRC_CHANNEL` environment variables.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Example contents:
 ```
 PORT=3000
 # IRC connection details are supplied by the frontend at runtime.
+# Set IRC_TLS=true to enable TLS by default when the frontend does not specify.
 ```
 
 ## Scripts

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -9,4 +9,8 @@ module.exports = defineConfig([
 		files: ['**/*.{js,cjs}'],
 		languageOptions: { globals: { ...globals.browser, ...globals.node } },
 	},
+	{
+		files: ['test/**/*.js'],
+		languageOptions: { globals: { ...globals.jest } },
+	},
 ]);

--- a/src/ircClientFactory.js
+++ b/src/ircClientFactory.js
@@ -9,162 +9,153 @@ const logger = require('./logger');
  * @returns {IRC.Client}
  */
 function createIrcClient(options, ws, entry, id, onDisconnect) {
-  const { server: host, port = 6697, nick, password } = options;
-  const ircClient = new IRC.Client();
-  entry.ircClient = ircClient;
+	const { server: host, port = 6697, nick, password, tls } = options;
+	const ircClient = new IRC.Client();
+	entry.ircClient = ircClient;
 
-  function cleanup(reason, notify = true) {
-    if (entry.ircClient) {
-      try {
-        ircClient.removeAllListeners();
-        ircClient.quit(reason || 'disconnect');
-        if (ircClient.connection && ircClient.connection.end) {
-          ircClient.connection.end();
-        }
-      } catch (err) {
-        logger.error('Error during IRC cleanup:', err);
-      }
-      entry.ircClient = null;
-      entry.ircReady = false;
-      if (notify && ws.readyState === ws.OPEN) {
-        ws.send(JSON.stringify({ type: 'disconnected', id }));
-      }
-      if (typeof onDisconnect === 'function') {
-        onDisconnect();
-      }
-    }
-  }
+	function cleanup(reason, notify = true) {
+		if (entry.ircClient) {
+			try {
+				ircClient.removeAllListeners();
+				ircClient.quit(reason || 'disconnect');
+				if (ircClient.connection && ircClient.connection.end) {
+					ircClient.connection.end();
+				}
+			} catch (err) {
+				logger.error('Error during IRC cleanup:', err);
+			}
+			entry.ircClient = null;
+			entry.ircReady = false;
+			if (notify && ws.readyState === ws.OPEN) {
+				ws.send(JSON.stringify({ type: 'disconnected', id }));
+			}
+			if (typeof onDisconnect === 'function') {
+				onDisconnect();
+			}
+		}
+	}
 
-  const useTLS =
-    port === 6697 || port === 7000 || port === 7070 || /libera\.chat$/.test(host);
-  logger.info(
-    `Connecting to IRC for ws: server=${host}, port=${port}, nick=${nick}, tls=${useTLS}`
-  );
+	const envTls = process.env.IRC_TLS;
+	const envTlsBool = typeof envTls === 'string' && ['1', 'true', 'yes'].includes(envTls.toLowerCase());
+	const useTLS = typeof tls === 'boolean' ? tls : envTlsBool;
+	logger.info(`Connecting to IRC for ws: server=${host}, port=${port}, nick=${nick}, tls=${useTLS}`);
 
-  ircClient.on('connecting', () => {
-    logger.info('IRC client: connecting...');
-  });
+	ircClient.on('connecting', () => {
+		logger.info('IRC client: connecting...');
+	});
 
-  ircClient.on('socket connected', () => {
-    logger.info('IRC client: socket connected');
-  });
+	ircClient.on('socket connected', () => {
+		logger.info('IRC client: socket connected');
+	});
 
-  ircClient.on('registered', () => {
-    entry.ircReady = true;
-    ws.send(JSON.stringify({ type: 'irc-ready', id }));
-    logger.info('Sent irc-ready to WebSocket client after IRC handshake');
-  });
+	ircClient.on('registered', () => {
+		entry.ircReady = true;
+		ws.send(JSON.stringify({ type: 'irc-ready', id }));
+		logger.info('Sent irc-ready to WebSocket client after IRC handshake');
+	});
 
-  ircClient.on('close', () => {
-    logger.warn('IRC client: connection closed');
-    if (ws.readyState === ws.OPEN) {
-      ws.send(JSON.stringify({ type: 'disconnected', id }));
-    }
-    cleanup('close', false);
-  });
+	ircClient.on('close', () => {
+		logger.warn('IRC client: connection closed');
+		if (ws.readyState === ws.OPEN) {
+			ws.send(JSON.stringify({ type: 'disconnected', id }));
+		}
+		cleanup('close', false);
+	});
 
-  ircClient.on('socket close', () => {
-    logger.warn('IRC client: socket closed');
-    if (ws.readyState === ws.OPEN) {
-      ws.send(JSON.stringify({ type: 'disconnected', id }));
-    }
-    cleanup('socket close', false);
-  });
+	ircClient.on('socket close', () => {
+		logger.warn('IRC client: socket closed');
+		if (ws.readyState === ws.OPEN) {
+			ws.send(JSON.stringify({ type: 'disconnected', id }));
+		}
+		cleanup('socket close', false);
+	});
 
-  ircClient.on('quit', (event) => {
-    logger.warn('IRC client: quit', event);
-  });
+	ircClient.on('quit', (event) => {
+		logger.warn('IRC client: quit', event);
+	});
 
-  ircClient.on('error', (err) => {
-    logger.error('IRC error:', err);
-    ws.send(
-      JSON.stringify({ type: 'error', id, error: 'IRC connection failed', details: err && err.message })
-    );
-    cleanup('error', false);
-  });
+	ircClient.on('error', (err) => {
+		logger.error('IRC error:', err);
+		ws.send(JSON.stringify({ type: 'error', id, error: 'IRC connection failed', details: err && err.message }));
+		cleanup('error', false);
+	});
 
-  ircClient.on('nick in use', (event) => {
-    logger.warn('IRC nick in use:', event);
-    const newNick = `${event.nick}${Math.floor(1000 + Math.random() * 9000)}`;
-    logger.info(`Trying new IRC nick: ${newNick}`);
-    ws.send(JSON.stringify({ type: 'nick', id, nick: newNick }));
-    ircClient.changeNick(newNick);
-  });
+	ircClient.on('nick in use', (event) => {
+		logger.warn('IRC nick in use:', event);
+		const newNick = `${event.nick}${Math.floor(1000 + Math.random() * 9000)}`;
+		logger.info(`Trying new IRC nick: ${newNick}`);
+		ws.send(JSON.stringify({ type: 'nick', id, nick: newNick }));
+		ircClient.changeNick(newNick);
+	});
 
-  ircClient.on('registration failed', (event) => {
-    logger.error('IRC registration failed:', event);
-  });
+	ircClient.on('registration failed', (event) => {
+		logger.error('IRC registration failed:', event);
+	});
 
-  ircClient.on('message', (event) => {
-    ws.send(
-      JSON.stringify({ type: 'message', id, from: event.nick, channel: event.target, text: event.message })
-    );
-  });
+	ircClient.on('message', (event) => {
+		ws.send(JSON.stringify({ type: 'message', id, from: event.nick, channel: event.target, text: event.message }));
+	});
 
-  ircClient.on('motd', (event) => {
-    ws.send(JSON.stringify({ type: 'server-message', id, subtype: 'motd', text: event.motd }));
-  });
+	ircClient.on('motd', (event) => {
+		ws.send(JSON.stringify({ type: 'server-message', id, subtype: 'motd', text: event.motd }));
+	});
 
-  ircClient.on('topic', (event) => {
-    ws.send(
-      JSON.stringify({ type: 'topic', id, channel: event.channel, topic: event.topic, nick: event.nick })
-    );
-  });
+	ircClient.on('topic', (event) => {
+		ws.send(JSON.stringify({ type: 'topic', id, channel: event.channel, topic: event.topic, nick: event.nick }));
+	});
 
-  ircClient.on('notice', (event) => {
-    if (!event.target || event.target === ircClient.user.nick) {
-      ws.send(
-        JSON.stringify({ type: 'server-message', id, subtype: 'notice', from: event.nick, text: event.message })
-      );
-    }
-  });
+	ircClient.on('notice', (event) => {
+		if (!event.target || event.target === ircClient.user.nick) {
+			ws.send(JSON.stringify({ type: 'server-message', id, subtype: 'notice', from: event.nick, text: event.message }));
+		}
+	});
 
-  ircClient.on('raw', (event) => {
-    logger.info('IRC RAW:', event);
+	ircClient.on('raw', (event) => {
+		logger.info('IRC RAW:', event);
 
-    if (event && event.command) {
-      const serverNumerics = ['001', '002', '003', '004', '005', '372', '375', '376'];
-      if (serverNumerics.includes(event.command)) {
-        ws.send(
-          JSON.stringify({
-            type: 'server-message',
-            id,
-            subtype: event.command,
-            text: event.params && event.params.join(' '),
-          })
-        );
-      }
-    }
+		if (event && event.command) {
+			const serverNumerics = ['001', '002', '003', '004', '005', '372', '375', '376'];
+			if (serverNumerics.includes(event.command)) {
+				ws.send(
+					JSON.stringify({
+						type: 'server-message',
+						id,
+						subtype: event.command,
+						text: event.params && event.params.join(' '),
+					})
+				);
+			}
+		}
 
-    if (event && event.line) {
-      const match = event.line.match(/\s353\s+\S+\s+[@=*]\s+(#\S+)\s+:([\S ]+)/);
-      if (match) {
-        const channel = match[1];
-        const nicks = match[2].split(' ').map((n) => n.replace(/^[@+]/, ''));
-        ws.send(JSON.stringify({ type: 'names', id, channel, nicks }));
-      }
-    }
-  });
+		if (event && event.line) {
+			const match = event.line.match(/\s353\s+\S+\s+[@=*]\s+(#\S+)\s+:([\S ]+)/);
+			if (match) {
+				const channel = match[1];
+				const nicks = match[2].split(' ').map((n) => n.replace(/^[@+]/, ''));
+				ws.send(JSON.stringify({ type: 'names', id, channel, nicks }));
+			}
+		}
+	});
 
-  ircClient.on('join', (event) => {
-    ws.send(JSON.stringify({ type: 'join', id, nick: event.nick, channel: event.channel }));
-  });
+	ircClient.on('join', (event) => {
+		ws.send(JSON.stringify({ type: 'join', id, nick: event.nick, channel: event.channel }));
+	});
 
-  ircClient.on('part', (event) => {
-    ws.send(JSON.stringify({ type: 'part', id, nick: event.nick, channel: event.channel }));
-  });
+	ircClient.on('part', (event) => {
+		ws.send(JSON.stringify({ type: 'part', id, nick: event.nick, channel: event.channel }));
+	});
 
-  ircClient.on('names', (event) => {
-    const nicks = event && event.users ? Object.keys(event.users) : [];
-    ws.send(JSON.stringify({ type: 'names', id, channel: event.channel, nicks }));
-  });
+	ircClient.on('names', (event) => {
+		const nicks = event && event.users ? Object.keys(event.users) : [];
+		ws.send(JSON.stringify({ type: 'names', id, channel: event.channel, nicks }));
+	});
 
-  ircClient.connect({ host, port, nick, password, tls: useTLS, auto_reconnect: false });
+	ircClient.connect({ host, port, nick, password, tls: useTLS, auto_reconnect: false });
 
-  // expose disconnect helper for manual cleanup
-  ircClient.disconnect = cleanup;
+	// expose disconnect helper for manual cleanup
+	ircClient.disconnect = cleanup;
 
-  return ircClient;
+	return ircClient;
 }
 
 module.exports = createIrcClient;

--- a/src/wsHandler.js
+++ b/src/wsHandler.js
@@ -8,29 +8,29 @@ const createIrcClient = require('./ircClientFactory');
  * @returns {WebSocketServer}
  */
 function setupWebSocketServer(server) {
-        const wss = new WebSocketServer({ server });
-        const wsIrcMap = new Map();
+	const wss = new WebSocketServer({ server });
+	const wsIrcMap = new Map();
 
 	wss.on('connection', (ws) => {
 		logger.info('WebSocket client connected');
-                wsIrcMap.set(ws, { ircSessions: new Map() });
+		wsIrcMap.set(ws, { ircSessions: new Map() });
 
-                ws.on('close', () => {
-                        logger.info('WebSocket client disconnected, cleaning up IRC clients');
-                        const entry = wsIrcMap.get(ws);
-                        if (entry) {
-                                for (const session of entry.ircSessions.values()) {
-                                        if (session.ircClient) {
-                                                try {
-                                                        session.ircClient.disconnect('WebSocket client disconnected', false);
-                                                } catch (err) {
-                                                        logger.error('Error cleaning IRC client:', err);
-                                                }
-                                        }
-                                }
-                        }
-                        wsIrcMap.delete(ws);
-                });
+		ws.on('close', () => {
+			logger.info('WebSocket client disconnected, cleaning up IRC clients');
+			const entry = wsIrcMap.get(ws);
+			if (entry) {
+				for (const session of entry.ircSessions.values()) {
+					if (session.ircClient) {
+						try {
+							session.ircClient.disconnect('WebSocket client disconnected', false);
+						} catch (err) {
+							logger.error('Error cleaning IRC client:', err);
+						}
+					}
+				}
+			}
+			wsIrcMap.delete(ws);
+		});
 
 		ws.on('message', (raw) => {
 			let msg;
@@ -42,81 +42,77 @@ function setupWebSocketServer(server) {
 				return;
 			}
 
-                        const entry = wsIrcMap.get(ws);
-                        const sessions = entry.ircSessions;
+			const entry = wsIrcMap.get(ws);
+			const sessions = entry.ircSessions;
 
-                        if (msg.type === 'connect') {
-                                if (!msg.id) {
-                                        ws.send(JSON.stringify({ type: 'error', error: 'Missing id' }));
-                                        return;
-                                }
-                                if (sessions.has(msg.id)) {
-                                        ws.send(JSON.stringify({ type: 'error', error: 'ID already connected' }));
-                                        return;
-                                }
-                                if (!msg.server || !msg.nick) {
-                                        ws.send(JSON.stringify({ type: 'error', error: 'Missing IRC server or nick' }));
-                                        return;
-                                }
+			if (msg.type === 'connect') {
+				if (!msg.id) {
+					ws.send(JSON.stringify({ type: 'error', error: 'Missing id' }));
+					return;
+				}
+				if (sessions.has(msg.id)) {
+					ws.send(JSON.stringify({ type: 'error', error: 'ID already connected' }));
+					return;
+				}
+				if (!msg.server || !msg.nick) {
+					ws.send(JSON.stringify({ type: 'error', error: 'Missing IRC server or nick' }));
+					return;
+				}
 
-                                const sessionEntry = { ircClient: null, ircReady: false };
-                                sessions.set(msg.id, sessionEntry);
-                                createIrcClient(
-                                        { server: msg.server, port: msg.port || 6697, nick: msg.nick, password: msg.password },
-                                        ws,
-                                        sessionEntry,
-                                        msg.id,
-                                        () => sessions.delete(msg.id)
-                                );
-                                return;
-                        }
+				const sessionEntry = { ircClient: null, ircReady: false };
+				sessions.set(msg.id, sessionEntry);
+				createIrcClient({ server: msg.server, port: msg.port || 6697, nick: msg.nick, password: msg.password, tls: msg.tls }, ws, sessionEntry, msg.id, () =>
+					sessions.delete(msg.id)
+				);
+				return;
+			}
 
-                        if (!msg.id) {
-                                ws.send(JSON.stringify({ type: 'error', error: 'Missing id' }));
-                                return;
-                        }
+			if (!msg.id) {
+				ws.send(JSON.stringify({ type: 'error', error: 'Missing id' }));
+				return;
+			}
 
-                        const session = sessions.get(msg.id);
+			const session = sessions.get(msg.id);
 
-                        if (!session || !session.ircClient || !session.ircReady) {
-                                ws.send(JSON.stringify({ type: 'error', error: 'IRC not connected' }));
-                                return;
-                        }
+			if (!session || !session.ircClient || !session.ircReady) {
+				ws.send(JSON.stringify({ type: 'error', error: 'IRC not connected' }));
+				return;
+			}
 
 			try {
 				switch (msg.type) {
-                                        case 'join':
-                                                if (msg.channel) {
-                                                        logger.info(`WS requests IRC join: ${msg.channel}`);
-                                                        session.ircClient.join(msg.channel);
-                                                }
-                                                break;
-                                        case 'message':
-                                                if (msg.channel && msg.text) {
-                                                        logger.info(`WS sends IRC message to ${msg.channel}: ${msg.text}`);
-                                                        session.ircClient.say(msg.channel, msg.text);
-                                                }
-                                                break;
-                                        case 'part':
-                                                if (msg.channel) {
-                                                        logger.info(`WS requests IRC part: ${msg.channel}`);
-                                                        session.ircClient.part(msg.channel);
-                                                }
-                                                break;
-                                       case 'names':
-                                               if (msg.channel) {
-                                                       logger.info(`WS requests IRC names for: ${msg.channel}`);
-                                                       session.ircClient.raw(`NAMES ${msg.channel}`);
-                                               }
-                                               break;
-                                       case 'disconnect':
-                                               logger.info(`WS requests IRC disconnect for session ${msg.id}`);
-                                               session.ircClient.disconnect('Client requested disconnect');
-                                               break;
-                                       default:
-                                               logger.warn('Unknown WS message type:', msg.type);
-                                               ws.send(JSON.stringify({ type: 'error', error: 'Unknown message type' }));
-                               }
+					case 'join':
+						if (msg.channel) {
+							logger.info(`WS requests IRC join: ${msg.channel}`);
+							session.ircClient.join(msg.channel);
+						}
+						break;
+					case 'message':
+						if (msg.channel && msg.text) {
+							logger.info(`WS sends IRC message to ${msg.channel}: ${msg.text}`);
+							session.ircClient.say(msg.channel, msg.text);
+						}
+						break;
+					case 'part':
+						if (msg.channel) {
+							logger.info(`WS requests IRC part: ${msg.channel}`);
+							session.ircClient.part(msg.channel);
+						}
+						break;
+					case 'names':
+						if (msg.channel) {
+							logger.info(`WS requests IRC names for: ${msg.channel}`);
+							session.ircClient.raw(`NAMES ${msg.channel}`);
+						}
+						break;
+					case 'disconnect':
+						logger.info(`WS requests IRC disconnect for session ${msg.id}`);
+						session.ircClient.disconnect('Client requested disconnect');
+						break;
+					default:
+						logger.warn('Unknown WS message type:', msg.type);
+						ws.send(JSON.stringify({ type: 'error', error: 'Unknown message type' }));
+				}
 			} catch (err) {
 				logger.error('Error handling WS message:', err);
 				ws.send(JSON.stringify({ type: 'error', error: 'Internal server error' }));


### PR DESCRIPTION
## Summary
- refactor `createIrcClient` to honour `tls` option and `IRC_TLS` env var
- pass `tls` through WebSocket connect messages
- document new behaviour and env var
- show `IRC_TLS` in README and `.env.example`
- add ESLint override for Jest tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ac9a958a8832ba6320bb4601c8f77