### PR TITLE
Add ISO timestamp to logger output

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -1,13 +1,14 @@
 const levels = ['error', 'warn', 'info', 'debug'];
 
 function log(level, ...args) {
+  const timestamp = new Date().toISOString();
   if (levels.includes(level)) {
     console[level === 'debug' ? 'log' : level](
-      `[${level.toUpperCase()}]`,
+      `[${timestamp}] [${level.toUpperCase()}]`,
       ...args
     );
   } else {
-    console.log('[LOG]', ...args);
+    console.log(`[${timestamp}] [LOG]`, ...args);
   }
 }
 


### PR DESCRIPTION
## Summary
- include ISO timestamps in logger output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687acfef0970832b94eb794ca8acd304