### PR TITLE
Add optional TLS flag to connect options

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -11,11 +11,12 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
 2. **Send IRC Connect Message:**
    - The frontend must send a message of the form:
      ```json
-     { "type": "connect", "id": "server1", "server": "irc.example.net", "nick": "myNick" }
+     { "type": "connect", "id": "server1", "server": "irc.example.net", "nick": "myNick", "tls": true }
      ```
      - `server`: IRC server hostname (required)
      - `nick`: IRC nickname (required)
      - `password`: (optional) Password for servers that require authentication
+     - `tls`: (optional) `true` or `false` to explicitly enable or disable TLS
    - No other IRC actions are allowed until the backend responds with `{"type": "irc-ready", "id": "<same id>"}`.
 3. **Wait for IRC Ready:**
    - The backend connects to the IRC server and performs the handshake.
@@ -53,7 +54,7 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
 1. **Frontend connects to backend WebSocket**
 2. **Frontend sends:**
    ```json
-   { "type": "connect", "id": "libera", "server": "irc.libera.chat", "nick": "alice" }
+   { "type": "connect", "id": "libera", "server": "irc.libera.chat", "nick": "alice", "tls": true }
    ```
 3. **Backend responds (after IRC handshake):**
    ```json
@@ -105,9 +106,9 @@ This document describes how to interact with the backend WebSocket IRC bridge fo
 
 - **Connect to IRC server**
   ```json
-  { "type": "connect", "id": "example", "server": "irc.example.net", "nick": "myNick" }
+  { "type": "connect", "id": "example", "server": "irc.example.net", "nick": "myNick", "tls": true }
   ```
-  (Optionally, add `"password": "..."` for servers that require authentication.)
+  (Optionally, add `"password": "..."` for servers that require authentication. Use `"tls"` to explicitly enable or disable TLS.)
 - **Join a channel**
   ```json
   { "type": "join", "id": "example", "channel": "#channel" }

--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ Endpoint: any path (example: `/ws`)
 Example messages:
 
 ```json
-{ "type": "connect", "id": "server1", "server": "irc.example.net", "nick": "myNick" }
+{ "type": "connect", "id": "server1", "server": "irc.example.net", "nick": "myNick", "tls": true }
 { "type": "join", "id": "server1", "channel": "#chat" }
 { "type": "message", "id": "server1", "channel": "#chat", "text": "Hello" }
 ```
+Use `"tls": true` to force a secure connection. If omitted, TLS is automatically
+enabled for standard secure ports (6697, 7000, 7070) and servers ending with
+`libera.chat`.
 
 <!--
 ### REST

--- a/src/ircClientFactory.js
+++ b/src/ircClientFactory.js
@@ -4,12 +4,17 @@ const logger = require('./logger');
 /**
  * Create and connect an IRC client, wiring events to the given WebSocket.
  * @param {Object} options - IRC connection options
+ * @param {string} options.server - IRC server hostname
+ * @param {number} [options.port=6697] - IRC server port
+ * @param {string} options.nick - IRC nickname
+ * @param {string} [options.password] - optional server password
+ * @param {boolean} [options.tls] - explicitly enable or disable TLS
  * @param {import('ws')} ws - WebSocket to relay IRC events to
  * @param {Object} entry - Map entry storing client state
  * @returns {IRC.Client}
  */
 function createIrcClient(options, ws, entry, id, onDisconnect) {
-  const { server: host, port = 6697, nick, password } = options;
+  const { server: host, port = 6697, nick, password, tls } = options;
   const ircClient = new IRC.Client();
   entry.ircClient = ircClient;
 
@@ -36,7 +41,12 @@ function createIrcClient(options, ws, entry, id, onDisconnect) {
   }
 
   const useTLS =
-    port === 6697 || port === 7000 || port === 7070 || /libera\.chat$/.test(host);
+    typeof tls === 'boolean'
+      ? tls
+      : port === 6697 ||
+        port === 7000 ||
+        port === 7070 ||
+        /libera\.chat$/.test(host);
   logger.info(
     `Connecting to IRC for ws: server=${host}, port=${port}, nick=${nick}, tls=${useTLS}`
   );

--- a/src/wsHandler.js
+++ b/src/wsHandler.js
@@ -62,7 +62,13 @@ function setupWebSocketServer(server) {
                                 const sessionEntry = { ircClient: null, ircReady: false };
                                 sessions.set(msg.id, sessionEntry);
                                 createIrcClient(
-                                        { server: msg.server, port: msg.port || 6697, nick: msg.nick, password: msg.password },
+                                        {
+                                                server: msg.server,
+                                                port: msg.port || 6697,
+                                                nick: msg.nick,
+                                                password: msg.password,
+                                                tls: msg.tls,
+                                        },
                                         ws,
                                         sessionEntry,
                                         msg.id,


### PR DESCRIPTION
## Summary
- allow passing a `tls` option into `createIrcClient`
- keep existing TLS heuristics if the option isn't provided
- expose the new parameter in wsHandler
- document TLS usage in README and DOCUMENTATION

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687ad55e8684832bb6f61814a55cc4b3